### PR TITLE
Remove boost dependency on mutex, thread and shared_ptr

### DIFF
--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -116,7 +116,7 @@ private:
   boost::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> laser_freq_;
   boost::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> echoes_freq_;
 
-  boost::mutex lidar_mutex_;
+  std::mutex lidar_mutex_;
 
   /* Non-const device properties.  If you poll the driver for these
   * while scanning is running, then the scan will probably fail.

--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -110,11 +110,11 @@ private:
   std::thread diagnostics_thread_;
   std::thread scan_thread_;
 
-  boost::shared_ptr<urg_node::URGCWrapper> urg_;
-  //boost::shared_ptr<dynamic_reconfigure::Server<urg_node::URGConfig> > srv_;  ///< Dynamic reconfigure server
-  boost::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
-  boost::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> laser_freq_;
-  boost::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> echoes_freq_;
+  std::shared_ptr<urg_node::URGCWrapper> urg_;
+  //std::shared_ptr<dynamic_reconfigure::Server<urg_node::URGConfig> > srv_;  ///< Dynamic reconfigure server
+  std::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
+  std::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> laser_freq_;
+  std::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> echoes_freq_;
 
   std::mutex lidar_mutex_;
 

--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -107,8 +107,8 @@ private:
   rclcpp::node::Node::SharedPtr nh_;
   rclcpp::node::Node::SharedPtr pnh_;
 
-  boost::thread diagnostics_thread_;
-  boost::thread scan_thread_;
+  std::thread diagnostics_thread_;
+  std::thread scan_thread_;
 
   boost::shared_ptr<urg_node::URGCWrapper> urg_;
   //boost::shared_ptr<dynamic_reconfigure::Server<urg_node::URGConfig> > srv_;  ///< Dynamic reconfigure server

--- a/src/urg_node_driver.cpp
+++ b/src/urg_node_driver.cpp
@@ -328,7 +328,7 @@ void UrgNode::updateDiagnostics()
   while (!close_diagnostics_)
   {
     diagnostic_updater_->update();
-    boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 }
 
@@ -498,7 +498,7 @@ void UrgNode::scanThread()
     {
       if (!connect())
       {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
         continue;  // Connect failed, sleep, try again.
       }
     }
@@ -528,7 +528,7 @@ void UrgNode::scanThread()
       srv_.reset(new dynamic_reconfigure::Server<urg_node::URGConfig>(pnh_));
       // Configure limits (Must do this after creating the urgwidget)
       update_reconfigure_limits();
-      srv_->setCallback(boost::bind(&UrgNode::reconfigure_callback, this, _1, _2));
+      srv_->setCallback(std::bind(&UrgNode::reconfigure_callback, this, _1, _2));
 #endif
     }
 
@@ -616,7 +616,7 @@ void UrgNode::scanThread()
 
       if (service_yield_)
       {
-        boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         service_yield_ = false;
       }
 
@@ -661,10 +661,10 @@ void UrgNode::run()
 
   // Now that we are setup, kick off diagnostics.
   close_diagnostics_ = false;
-  diagnostics_thread_ = boost::thread(boost::bind(&UrgNode::updateDiagnostics, this));
+  diagnostics_thread_ = std::thread(std::bind(&UrgNode::updateDiagnostics, this));
 
   // Start scanning now that everything is configured.
   close_scan_ = false;
-  scan_thread_ = boost::thread(boost::bind(&UrgNode::scanThread, this));
+  scan_thread_ = std::thread(std::bind(&UrgNode::scanThread, this));
 }
 }  // namespace urg_node

--- a/src/urg_node_driver.cpp
+++ b/src/urg_node_driver.cpp
@@ -150,7 +150,7 @@ bool UrgNode::updateStatus()
 {
   bool result = false;
   service_yield_ = true;
-  boost::mutex::scoped_lock lock(lidar_mutex_);
+  std::unique_lock<std::mutex> lock(lidar_mutex_);
 
   if (urg_)
   {
@@ -294,7 +294,7 @@ void UrgNode::update_reconfigure_limits()
 
 void UrgNode::calibrate_time_offset()
 {
-  boost::mutex::scoped_lock lock(lidar_mutex_);
+  std::unique_lock<std::mutex> lock(lidar_mutex_);
   if (!urg_)
   {
     //ROS_DEBUG_THROTTLE(10, "Unable to calibrate time offset. Not Ready.");
@@ -403,7 +403,7 @@ bool UrgNode::connect()
 {
   // Don't let external access to retrieve
   // status during the connection process.
-  boost::mutex::scoped_lock lock(lidar_mutex_);
+  std::unique_lock<std::mutex> lock(lidar_mutex_);
 
   try
   {
@@ -573,7 +573,7 @@ void UrgNode::scanThread()
       // Don't allow external access during grabbing the scan.
       try
       {
-        boost::mutex::scoped_lock lock(lidar_mutex_);
+        std::unique_lock<std::mutex> lock(lidar_mutex_);
         if (publish_multiecho_)
         {
           const sensor_msgs::msg::MultiEchoLaserScan::SharedPtr msg(new sensor_msgs::msg::MultiEchoLaserScan());


### PR DESCRIPTION
Replace boost::mutex::scoped_lock with std::unique_lock<std::mutex>
Replace boost::mutex with std::mutex
Replace boost::thread with std::thread
Replace boost::shared_ptr with std::shared_ptr







