### PR TITLE
Support for IP address and port of the Lidar to be passed as an argument

### DIFF
--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -78,6 +78,20 @@ public:
   void setLaserFrameId(const std::string& laserFrameId);
 
   /**
+   * @brief Set the IP Address
+   * Set the IP address used by the lidar
+   * @param ipAddr is the IP address
+   */
+  void setIPAdddress(const std::string& ipAddr);
+
+  /**
+   * @brief Set the IP port
+   * Set the IP port used by the lidar
+   * @param ipPort is the IP port
+   */
+  void setIPPort(const int& ipPort);
+
+  /**
    * @brief Start's the nodes threads to run the lidar.
    */
   void run();

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -61,6 +61,21 @@ int main(int argc, char **argv)
     userLatency = boost::lexical_cast<double>(strLatency);
   }
 
+  // Support the optional IP address command line argument
+  std::string ipAddress = "";
+  option = "--ip-addr";
+  if (rcutils_cli_option_exist(argv, argv + argc, option.c_str())) {
+    ipAddress = rcutils_cli_get_option(argv, argv + argc, option.c_str());
+  }
+
+  // Support the optional IP port command line argument
+  int ipPort = 0;
+  option = "--port";
+  if (rcutils_cli_option_exist(argv, argv + argc, option.c_str())) {
+    std::string strIPPort = rcutils_cli_get_option(argv, argv + argc, option.c_str());
+    ipPort = boost::lexical_cast<int>(strIPPort);
+  }
+
   // Support the optional laser frame id command line argument
   std::string laserFrameId = "laser";
   option = "--laser-frame-id";
@@ -73,6 +88,8 @@ int main(int argc, char **argv)
   // Update settings
   urgNode.setSerialPort(serialPort);
   urgNode.setUserLatency(userLatency);
+  urgNode.setIPAdddress(ipAddress);
+  urgNode.setIPPort(ipPort);
 
   // Run the urg node
   urgNode.run();

--- a/src/urg_node_driver.cpp
+++ b/src/urg_node_driver.cpp
@@ -62,6 +62,16 @@ void UrgNode::setSerialPort(const std::string& port)
   serial_port_ = port;
 }
 
+void UrgNode::setIPAdddress(const std::string& ipAddr)
+{
+  ip_address_ = ipAddr;
+}
+
+void UrgNode::setIPPort(const int& ipPort)
+{
+  ip_port_ = ipPort;
+}
+
 void UrgNode::setUserLatency(const double& latency)
 {
   default_user_latency_ = latency;


### PR DESCRIPTION
IP address and port can be passed as an argument, for this PR they can only be called via run command, support for launch command can be added after [this issue](https://github.com/bponsler/urg_node/issues/9) is resolved. Example Usage : 

`ros2 run urg_node urg_node --ip-addr 192.168.7.8 --port 12344`
